### PR TITLE
Where is Bernard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "suggest": {
         "bernard/bernard": "Publish asynchronously &| publish in amqp queue.",
+        "bernard/bernard-bundle": "Bundle to integrate bernard/bernard in Symfony project",
         "guzzlehttp/guzzle": "Communicate threw HTTP gateway."
     },
     "autoload": {


### PR DESCRIPTION
As `wow.message_bus_publisher.prooph_plugin` require `bernard.producer` service and this service is not declared in bernard/bernard but in bernard/bernard-bundle, we shall suggest directly bernard-bundle to meet requirements.

> And then add Bernard\BernardBundle\BernardBernardBundle in appKernel:
![](http://s2.lemde.fr/image/2013/10/05/534x267/3490428_3_49b7_bernard-tapie-le-10-juillet-2013_4ef739f7f2ecce3baea6967a14bdd652.jpg)