### PR TITLE
Fix message routing

### DIFF
--- a/src/Infra/Router/InMemory/MessageRouter.php
+++ b/src/Infra/Router/InMemory/MessageRouter.php
@@ -43,7 +43,7 @@ class MessageRouter implements MessageRouterInterface
      */
     public function route($message): array
     {
-        $messageId = $this->messageIdentifierResolver->resolve($message);
+        $messageId = get_class($message);
 
         if (false === array_key_exists($messageId, $this->routes)) {
             return [];


### PR DESCRIPTION
The route listing in `$this->routes` have the FQCN (incoming from the driver.in_memory.routing) for keys, and not a service name like `service.service_created`.